### PR TITLE
Processor enable disable

### DIFF
--- a/Entities/Workflow.cs
+++ b/Entities/Workflow.cs
@@ -10,6 +10,7 @@ namespace LimsServer.Entities
         //private string BaseNetworkPath = @"\\AA\ORD\ORD\PRIV";
         public string id { get; set; }
         public string name { get; set; }
+        // Processor Name
         public string processor { get; set; }
         public string inputFolder { get; set; }
         public string outputFolder { get; set; }
@@ -30,7 +31,7 @@ namespace LimsServer.Entities
             this.outputFolder = wf.outputFolder;
             this.interval = wf.interval;
             this.message = "";
-            this.active = true;
+            this.active = wf.active;
         }
 
     }

--- a/LimsServerTests/ProcessorServiceTest.cs
+++ b/LimsServerTests/ProcessorServiceTest.cs
@@ -102,10 +102,10 @@ namespace LimsServerTests
             this._context.Processors.AddAsync(p1);
             this._context.SaveChangesAsync();
 
-            var result = ps.GetById(p1.name).Result;
+            var result = ps.GetByName(p1.name).Result;
             Assert.NotNull(result);
 
-            var badResult = ps.GetById("fakeID").Result;
+            var badResult = ps.GetByName("fakeID").Result;
             Assert.Null(badResult);
         }
 

--- a/lims_server/LoadProcessorsService.cs
+++ b/lims_server/LoadProcessorsService.cs
@@ -54,7 +54,7 @@ namespace LimsServer
                     lstProcs.Add(proc);
                     procsInDb.Add(proc.name.ToLower());
                 }
-                
+
                 //Set all the processors in the db to enabled = false
                 await procService.Update(lstProcs.ToArray());
 
@@ -62,7 +62,7 @@ namespace LimsServer
                 lstProcs = new List<Processor>();
                 foreach (string proc in procsIntersect)
                 {
-                    var processor = await procService.GetById(proc);
+                    var processor = await procService.GetByName(proc);
                     //Processor processor = result.Result;
                     processor.enabled = true;
                     lstProcs.Add(processor);
@@ -73,7 +73,7 @@ namespace LimsServer
 
                 var newProcs = procsDiskNames.Except(procsInDb);
                 List<ProcessorDTO> lstProcDTO = new List<ProcessorDTO>();
-                foreach(string proc in newProcs)                
+                foreach (string proc in newProcs)
                     lstProcDTO.Add(procsFromDisk.Find(x => x.Name.ToLower() == proc.ToLower()));
 
                 foreach (ProcessorDTO proc in lstProcDTO)
@@ -91,7 +91,7 @@ namespace LimsServer
 
             //return System.Threading.Tasks.Task.CompletedTask;
             return;
-            
+
         }
     }
 }

--- a/lims_server/Services/ProcessorService.cs
+++ b/lims_server/Services/ProcessorService.cs
@@ -13,10 +13,10 @@ namespace LimsServer.Services
     {
         System.Threading.Tasks.Task<IEnumerable<Processor>> GetAll();
         Task<Processor> GetById(string id);
+        Task<Processor> GetByName(string name);
         Task<Processor> Create(Processor processor);
         System.Threading.Tasks.Task Update(string id, Processor processor);
         System.Threading.Tasks.Task Update(Processor[] processor);
-
     }
 
     public class ProcessorService : IProcessorService
@@ -64,13 +64,32 @@ namespace LimsServer.Services
         /// <summary>
         /// Query processors for specified id.
         /// </summary>
+        /// <param name="name">processor name</param>
+        /// <returns>the processor with the specified name</returns>
+        public async Task<Processor> GetByName(string name)
+        {
+            try
+            {
+                var processor = await _context.Processors.SingleAsync(p => p.name == name);
+                return processor as Processor;
+            }
+            catch (InvalidOperationException)
+            {
+                Serilog.Log.Information("No processor found with name: {0}", name);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Query processors for specified id.
+        /// </summary>
         /// <param name="id">processor ID</param>
         /// <returns>the processor with the specified ID</returns>
         public async Task<Processor> GetById(string id)
         {
             try
             {
-                var processor = await _context.Processors.SingleAsync(w => w.name == id);
+                var processor = await _context.Processors.SingleAsync(p => p.id == id);
                 return processor as Processor;
             }
             catch (InvalidOperationException)
@@ -93,6 +112,8 @@ namespace LimsServer.Services
                 p.version = processor.version;
                 p.file_type = processor.file_type;
                 p.description = processor.description;
+                p.enabled = processor.enabled;
+                p.process_found = processor.process_found;
                 await _context.SaveChangesAsync();
             }
             catch (InvalidOperationException)
@@ -110,6 +131,5 @@ namespace LimsServer.Services
             _context.Processors.UpdateRange(processors);
             await _context.SaveChangesAsync();
         }
-
     }
 }


### PR DESCRIPTION
- Added API call to toggle the processor state.
> If processor set to disabled, all corresponding workflows are updated to active = false. All scheduled/running tasks are set to cancelled and stopped, and all completed tasks are left as is. 
> If processor set to enabled from disabled, all workflows and tasks left as is. 
- Updated some functions to assign necessary data.
- Added GetByName function to processors.